### PR TITLE
ci: Fix release process

### DIFF
--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -57,7 +57,6 @@ jobs:
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           generate_release_notes: true
-          files: |
-            logwatcher-*.vsix
+          files: logwatcher-*.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}


### PR DESCRIPTION
Ref: https://github.com/Automattic/vscode-logwatcher/actions/runs/5214903083/jobs/9412173975#step:6:1

```
Run softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
👩‍🏭 Creating new GitHub release for tag v0.0.1...
⚠️ GitHub release failed with status: 404
undefined
retrying... (2 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.0.1...
⚠️ GitHub release failed with status: 404
undefined
retrying... (1 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.0.1...
⚠️ GitHub release failed with status: 404
undefined
retrying... (0 retries remaining)
❌ Too many retries. Aborting...
Error: Too many retries.
```