### PR TITLE
ci: Replace node-version with node-version-file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js environment
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 16.x
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node.js environment
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 16.x
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Node.js environment
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 16.x
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/vsce-publish.yml
+++ b/.github/workflows/vsce-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js environment
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 16.x
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
With this change, we only need to update `package.json`, and all workflows will use the updated version of Node.js.
