### PR TITLE
revert: Bump @types/vscode from 1.78.1 to 1.79.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.0.0",
-        "@types/vscode": "^1.79.0",
+        "@types/vscode": "^1.78.0",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
         "@vscode/test-electron": "^2.3.2",
@@ -238,9 +238,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.0.tgz",
-      "integrity": "sha512-Tfowu2rSW8hVGbqzQLSPlOEiIOYYryTkgJ+chMecpYiJcnw9n0essvSiclnK+Qh/TcSVJHgaK4EMrQDZjZJ/Sw==",
+      "version": "1.78.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.1.tgz",
+      "integrity": "sha512-wEA+54axejHu7DhcUfnFBan1IqFD1gBDxAFz8LoX06NbNDMRJv/T6OGthOs52yZccasKfN588EyffHWABkR0fg==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.0.0",
-    "@types/vscode": "^1.79.0",
+    "@types/vscode": "^1.78.0",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "@vscode/test-electron": "^2.3.2",


### PR DESCRIPTION
Reverts Automattic/vscode-logwatcher#7

```
> vsce package

 ERROR  @types/vscode ^1.79.0 greater than engines.vscode ^1.78.0. Consider upgrade engines.vscode or use an older @types/vscode version
```
