### PR TITLE
chore: update engine requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/node": "^16.0.0",
+        "@types/node": "^20.18.2",
         "@types/vscode": "^1.78.0",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
@@ -22,8 +22,8 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": "^16.0.0",
-        "vscode": "^1.78.0"
+        "node": ">= 20.18.2",
+        "vscode": "^1.97.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -783,11 +783,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -5934,6 +5937,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/Automattic/vscode-logwatcher",
   "engines": {
-    "vscode": "^1.78.0",
-    "node": "^16.0.0"
+    "vscode": "^1.97.0",
+    "node": ">= 20.18.2"
   },
   "categories": [
     "Other"
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@types/node": "^16.0.0",
+    "@types/node": "^20.18.2",
     "@types/vscode": "^1.78.0",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",


### PR DESCRIPTION
This pull request updates the project's dependencies to require more recent versions of both Node.js and VS Code, ensuring compatibility with the latest features and security updates.

Dependency and engine updates:

* Increased the minimum required VS Code version to `^1.97.0` and Node.js version to `>= 20.18.2` in the `engines` field of `package.json`.
* Updated the `@types/node` development dependency to version `^20.18.2` in `package.json`.

These changes set the minimum supported version of VSCode to [1.98 (February 2025)](https://code.visualstudio.com/updates/v1_98).