### PR TITLE
test: workaround for microsoft/vscode#232559

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -5,7 +5,7 @@ export interface Resource {
     outputChannel: OutputChannel;
     watcher: FileSystemWatcher;
     emitter: EventEmitter;
-    disposables?: Disposable[];
+    disposables: Disposable[];
 }
 
 const resources = new Map<string, Resource>();
@@ -20,13 +20,13 @@ export function addResource(path: string, resource: Resource): boolean {
 }
 
 function doFreeResource(resource: Resource): void {
-    if (resource.disposables) {
-        resource.disposables.forEach((disposable) => disposable.dispose());
-    }
-
-    resource.outputChannel.dispose();
-    resource.watcher.dispose();
+    resource.disposables.forEach((disposable) => disposable.dispose());
     resource.emitter.removeAllListeners();
+    resource.watcher.dispose();
+    // See https://github.com/microsoft/vscode/issues/232559
+    if (process.env.NODE_ENV !== 'test') {
+        resource.outputChannel.dispose();
+    }
 }
 
 export function freeResource(path: string): void {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -11,6 +11,7 @@ async function main(): Promise<void> {
         // Passed to --extensionTestsPath
         const extensionTestsPath = resolve(__dirname, './suite/index');
 
+        process.env.NODE_ENV = 'test';
         // Download VS Code, unzip it and run the integration test
         await runTests({
             extensionDevelopmentPath,

--- a/src/test/suite/resources.test.ts
+++ b/src/test/suite/resources.test.ts
@@ -5,7 +5,7 @@ import { RelativePattern, Uri, window, workspace } from 'vscode';
 import { Resource, addResource, freeAllResources, freeResource, getFilenames, getResource } from '../../resources';
 
 function createResource(filename: string): Resource {
-    const outputChannel = window.createOutputChannel(filename);
+    const outputChannel = window.createOutputChannel(filename, 'log');
     const watcher = workspace.createFileSystemWatcher(
         new RelativePattern(Uri.file(filename), basename(filename)),
         false,
@@ -14,7 +14,7 @@ function createResource(filename: string): Resource {
     );
     const emitter = new EventEmitter();
 
-    return { outputChannel, watcher, emitter };
+    return { outputChannel, watcher, emitter, disposables: [] };
 }
 
 suite('Resources', function () {

--- a/src/test/suite/watchfilecommand.test.ts
+++ b/src/test/suite/watchfilecommand.test.ts
@@ -22,7 +22,7 @@ const waitForVisibleRangesChange = (editor: TextEditor): Promise<void> =>
 const promisifiedWrite = (stream: WriteStream, data: string | Buffer): Promise<void> => new Promise((resolve) => stream.end(data, resolve));
 const nextTick = (): Promise<void> => new Promise((resolve) => process.nextTick(resolve));
 const delay = async (): Promise<void> => {
-    await setTimeout(platform() === 'win32' ? 1000 : 0);
+    await setTimeout(platform() === 'win32' ? 1000 : 50);
 };
 
 suite('WatchFileCommand', function () {

--- a/src/test/suite/watchfilecommand.test.ts
+++ b/src/test/suite/watchfilecommand.test.ts
@@ -22,7 +22,7 @@ const waitForVisibleRangesChange = (editor: TextEditor): Promise<void> =>
 const promisifiedWrite = (stream: WriteStream, data: string | Buffer): Promise<void> => new Promise((resolve) => stream.end(data, resolve));
 const nextTick = (): Promise<void> => new Promise((resolve) => process.nextTick(resolve));
 const delay = async (): Promise<void> => {
-    await setTimeout(platform() === 'win32' ? 1000 : 200);
+    await setTimeout(platform() === 'win32' ? 1000 : 0);
 };
 
 suite('WatchFileCommand', function () {

--- a/src/watchfilecommand.ts
+++ b/src/watchfilecommand.ts
@@ -65,7 +65,6 @@ function maybeShowOutput(outputChannel: OutputChannel, preserveFocus?: boolean |
 async function setUpWatcher(filename: string): Promise<Resource | null> {
     const emitter = new EventEmitter();
     const outputChannel = window.createOutputChannel(`Watch ${filename}`, 'log');
-    const output = outputChannel;
     const stats = await statFile(filename);
     let offset = stats?.size ?? 0;
 
@@ -96,14 +95,14 @@ async function setUpWatcher(filename: string): Promise<Resource | null> {
 
     watcher.onDidDelete(() => {
         offset = 0;
-        output.appendLine(`*** File ${filename} has disappeared`);
-        maybeShowOutput(output, true);
-        process.nextTick(() => emitter?.emit('fileDeleted', filename));
+        outputChannel.appendLine(`*** File ${filename} has disappeared`);
+        maybeShowOutput(outputChannel, true);
+        process.nextTick(() => emitter.emit('fileDeleted', filename));
     }, null, resource.disposables);
 
     watcher.onDidCreate(() => {
         offset = 0;
-        process.nextTick(() => emitter?.emit('fileCreated', filename));
+        process.nextTick(() => emitter.emit('fileCreated', filename));
     }, null, resource.disposables);
 
     watcher.onDidChange(async () => {
@@ -116,16 +115,16 @@ async function setUpWatcher(filename: string): Promise<Resource | null> {
                 const buffer = Buffer.alloc(stats.size - offset);
                 await fd.read(buffer, 0, buffer.length, offset);
                 offset += buffer.length;
-                output.append(buffer.toString('ascii'));
+                outputChannel.append(buffer.toString('ascii'));
             }
         } catch (err) {
-            output.appendLine(`*** Failed to read file ${filename}: ${(err as Error).message}`);
+            outputChannel.appendLine(`*** Failed to read file ${filename}: ${(err as Error).message}`);
         } finally {
             await fd?.close();
         }
 
-        maybeShowOutput(output, true);
-        process.nextTick(() => emitter?.emit('fileChanged', filename));
+        maybeShowOutput(outputChannel, true);
+        process.nextTick(() => emitter.emit('fileChanged', filename));
     }, null, resource.disposables);
 
     addResource(filename, resource);


### PR DESCRIPTION
This pull request makes several improvements to resource management and test reliability in the codebase. The main changes include stricter typing for resource disposables, safer resource cleanup (especially for output channels during tests), and minor test and logging enhancements.

**Resource Management Improvements:**

* Made the `disposables` property in the `Resource` interface required, ensuring all resources consistently manage their disposables.
* Updated the `doFreeResource` function to always dispose of items in `disposables` and to only dispose of the `outputChannel` outside of test environments, addressing an upstream VS Code issue.
* Updated resource creation in tests to always include an empty `disposables` array and specify the output channel type as `'log'` for clarity and consistency. [[1]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afL8-R8) [[2]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afL17-R17)

**Test Suite Enhancements:**

* Set `process.env.NODE_ENV` to `'test'` during test runs to prevent disposal of output channels in tests, improving test reliability.
* Reduced artificial delays in tests on non-Windows platforms for faster test execution.

**Logging and Event Handling Cleanup:**

* Simplified and standardized usage of `outputChannel` and event emitters in `setUpWatcher`, removing unnecessary null checks and improving code clarity. [[1]](diffhunk://#diff-f54d48847529af0c89791013ae25eecec3a8ea251593b771aa9248bb6a4bf4e6L68) [[2]](diffhunk://#diff-f54d48847529af0c89791013ae25eecec3a8ea251593b771aa9248bb6a4bf4e6L99-R105) [[3]](diffhunk://#diff-f54d48847529af0c89791013ae25eecec3a8ea251593b771aa9248bb6a4bf4e6L119-R127)