### PR TITLE
test: use strict assertions

### DIFF
--- a/src/test/suite/stopwatchingcommand.test.ts
+++ b/src/test/suite/stopwatchingcommand.test.ts
@@ -1,9 +1,13 @@
-import { equal, notEqual } from 'node:assert';
+import { equal, notEqual } from 'node:assert/strict';
 import { commands } from 'vscode';
 import { waitForOutputWindow } from './utils';
-import { getFilenames } from '../../resources';
+import { freeAllResources, getFilenames } from '../../resources';
 
 suite('StopWatchingCommand', function () {
+    this.afterEach(function () {
+        freeAllResources();
+    });
+
     test('cancel effect of watchFileCommand', async function () {
         const filename = __filename;
 

--- a/src/test/suite/watchfilecommand.test.ts
+++ b/src/test/suite/watchfilecommand.test.ts
@@ -1,4 +1,4 @@
-import { deepEqual, equal, match, notEqual } from 'node:assert';
+import { deepEqual, equal, match, notEqual } from 'node:assert/strict';
 import { EventEmitter, once } from 'node:events';
 import { WriteStream, createWriteStream } from 'node:fs';
 import { mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
@@ -44,7 +44,7 @@ suite('WatchFileCommand', function () {
 
     this.timeout('win32' === platform() ? 20000 : 2000);
 
-    test('watchFileCommandHandler - smoke test', async function () {
+    test('smoke test', async function () {
         const filename = __filename;
 
         const [editor] = await Promise.all([
@@ -56,7 +56,7 @@ suite('WatchFileCommand', function () {
         match(editor?.document.fileName ?? '', new RegExp(`Watch ${filename.replace(/\\/gu, '\\\\')}$`, 'u'));
     });
 
-    test('watchFileCommandHandler - react to file creation', async function () {
+    test('react to file creation', async function () {
         const fname = join(tmpDir, '0001.txt');
 
         const [editor, emitter] = await Promise.all([
@@ -71,7 +71,7 @@ suite('WatchFileCommand', function () {
         await Promise.all([once(emitter, 'fileCreated'), writeFile(fname, '')]);
     });
 
-    test('watchFileCommandHandler - react to file modification', async function () {
+    test('react to file modification', async function () {
         const fname = join(tmpDir, '0002.txt');
 
         const stream = createWriteStream(fname);
@@ -96,7 +96,7 @@ suite('WatchFileCommand', function () {
         equal(actual, expectedContent);
     });
 
-    test('watchFileCommandHandler - react to file removal', async function () {
+    test('react to file removal', async function () {
         const fname = join(tmpDir, '0003.txt');
 
         await writeFile(fname, '');
@@ -117,7 +117,7 @@ suite('WatchFileCommand', function () {
         equal(actual, expected);
     });
 
-    test('watchFileCommandHandler - preload last 10 lines', async function () {
+    test('preload last 10 lines', async function () {
         const fname = join(tmpDir, '0004.txt');
 
         const expectedContent = '1\n2\n3\n4\n5\n6\n7\n8\n9\nA\n';
@@ -139,8 +139,7 @@ suite('WatchFileCommand', function () {
         equal(actual, expectedContent);
     });
 
-    test('watchFileCommandHandler - preload entire file if less than 10 lines', async function () {
-        tmpDir = await mkdtemp(join(tmpdir(), 'logwatcher-test-'));
+    test('preload entire file if less than 10 lines', async function () {
         const fname = join(tmpDir, '0005.txt');
 
         const expectedContent = '1\n2\n3\n';
@@ -162,7 +161,7 @@ suite('WatchFileCommand', function () {
         equal(actual, expectedContent);
     });
 
-    test('watchFileCommandHandler - reuse existing output channel', async function () {
+    test('reuse existing output channel', async function () {
         const filename = __filename;
 
         await commands.executeCommand('logwatcher.watchFile', filename);


### PR DESCRIPTION
This pull request makes several improvements to the test suite for the `WatchFileCommand` and `StopWatchingCommand`. The main changes include updating imports for stricter assertions, cleaning up resources after tests, and simplifying test names for clarity and consistency.

**Test infrastructure improvements:**

* Updated imports from `'node:assert'` to `'node:assert/strict'` in both `stopwatchingcommand.test.ts` and `watchfilecommand.test.ts` for stricter assertion checks. [[1]](diffhunk://#diff-f581c2e10507d00a4a6a147d911c04a9bfb17513ef7868587ce4de622244c1f3L1-R10) [[2]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L1-R1)
* Added a call to `freeAllResources()` in the `afterEach` hook of `StopWatchingCommand` tests to ensure resources are cleaned up after each test.

**Test naming and clarity:**

* Simplified and standardized test case names in `watchfilecommand.test.ts` by removing redundant handler descriptions and using concise names (e.g., `'smoke test'`, `'react to file creation'`, `'preload last 10 lines'`). [[1]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L47-R47) [[2]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L59-R59) [[3]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L74-R74) [[4]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L99-R99) [[5]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L120-R120) [[6]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L142-R142) [[7]](diffhunk://#diff-31a06bc576498861ad72d7895a13866431a061aad04ca9e4637298f265c43202L165-R164)