### PR TITLE
test: properly handle DisposableStore bugs in tests

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -23,10 +23,7 @@ function doFreeResource(resource: Resource): void {
     resource.disposables.forEach((disposable) => disposable.dispose());
     resource.emitter.removeAllListeners();
     resource.watcher.dispose();
-    // See https://github.com/microsoft/vscode/issues/232559
-    if (process.env.NODE_ENV !== 'test') {
-        resource.outputChannel.dispose();
-    }
+    resource.outputChannel.dispose();
 }
 
 export function freeResource(path: string): void {

--- a/src/test/suite/resources.test.ts
+++ b/src/test/suite/resources.test.ts
@@ -3,8 +3,10 @@ import { basename, join } from 'node:path';
 import { EventEmitter } from 'node:events';
 import { RelativePattern, Uri, window, workspace } from 'vscode';
 import { Resource, addResource, freeAllResources, freeResource, getFilenames, getResource } from '../../resources';
+import { waitForOutputWindow } from './utils';
 
-function createResource(filename: string): Resource {
+async function createResource(filename: string): Promise<Resource> {
+    const promise = waitForOutputWindow(`extension-output-`);
     const outputChannel = window.createOutputChannel(filename, 'log');
     const watcher = workspace.createFileSystemWatcher(
         new RelativePattern(Uri.file(filename), basename(filename)),
@@ -14,6 +16,8 @@ function createResource(filename: string): Resource {
     );
     const emitter = new EventEmitter();
 
+    outputChannel.show(true);
+    await promise;
     return { outputChannel, watcher, emitter, disposables: [] };
 }
 
@@ -22,9 +26,9 @@ suite('Resources', function () {
         freeAllResources();
     });
 
-    test('addResource', function () {
+    test('addResource', async function () {
         const filename = __filename;
-        const r = createResource(filename);
+        const r = await createResource(filename);
 
         const added = addResource(filename, r);
         equal(added, true);
@@ -33,11 +37,11 @@ suite('Resources', function () {
         deepEqual(resource, r);
     });
 
-    test('freeResource', function () {
+    test('freeResource', async function () {
         let resource;
         const filename = __filename;
 
-        const added = addResource(filename, createResource(filename));
+        const added = addResource(filename, await createResource(filename));
         equal(added, true);
 
         resource = getResource(filename);
@@ -49,15 +53,15 @@ suite('Resources', function () {
         equal(resource, undefined);
     });
 
-    test('freeAllResources', function () {
+    test('freeAllResources', async function () {
         let resource;
         let added;
         const filename1 = __filename;
         const filename2 = join(__dirname, 'index.js');
 
-        added = addResource(filename1, createResource(filename1));
+        added = addResource(filename1, await createResource(filename1));
         equal(added, true);
-        added = addResource(filename2, createResource(filename2));
+        added = addResource(filename2, await createResource(filename2));
         equal(added, true);
 
         resource = getResource(filename1);
@@ -73,14 +77,14 @@ suite('Resources', function () {
         equal(resource, undefined);
     });
 
-    test('getFilenames', function () {
+    test('getFilenames', async function () {
         let added;
         const filename1 = __filename;
         const filename2 = join(__dirname, 'index.js');
 
-        added = addResource(filename1, createResource(filename1));
+        added = addResource(filename1, await createResource(filename1));
         equal(added, true);
-        added = addResource(filename2, createResource(filename2));
+        added = addResource(filename2, await createResource(filename2));
         equal(added, true);
 
         const expected = [filename1, filename2];

--- a/src/test/suite/watchfilecommand.test.ts
+++ b/src/test/suite/watchfilecommand.test.ts
@@ -21,9 +21,7 @@ const waitForVisibleRangesChange = (editor: TextEditor): Promise<void> =>
 
 const promisifiedWrite = (stream: WriteStream, data: string | Buffer): Promise<void> => new Promise((resolve) => stream.end(data, resolve));
 const nextTick = (): Promise<void> => new Promise((resolve) => process.nextTick(resolve));
-const delay = async (): Promise<void> => {
-    await setTimeout(platform() === 'win32' ? 1000 : 50);
-};
+const delay = (): Promise<unknown> => setTimeout(platform() === 'win32' ? 1000 : 50);
 
 suite('WatchFileCommand', function () {
     let tmpDir: string;
@@ -164,8 +162,16 @@ suite('WatchFileCommand', function () {
     test('reuse existing output channel', async function () {
         const filename = __filename;
 
-        await commands.executeCommand('logwatcher.watchFile', filename);
-        await commands.executeCommand('logwatcher.watchFile', filename);
+        const [_, emitter1] = await Promise.all([
+            waitForOutputWindow(`extension-output-`),
+            commands.executeCommand<EventEmitter>('logwatcher.watchFile', filename),
+        ]);
+
+        const emitter2 = await commands.executeCommand<EventEmitter>('logwatcher.watchFile', filename);
+
+        equal(emitter1 === emitter2, true);
+        notEqual(emitter1, null);
+        notEqual(emitter2, null);
 
         const expected = [filename];
         const actual = getFilenames();


### PR DESCRIPTION
This pull request improves resource cleanup and reliability in both the resource management code and its associated tests. The main changes ensure that resources are always fully disposed of, and that tests properly wait for the output channel to be ready before proceeding. Additionally, the test code has been modernized to use async functions and improved delay handling.

**Resource management improvements:**

* The `outputChannel` is now always disposed of in `doFreeResource`, regardless of the environment, ensuring resources are consistently cleaned up.

**Test reliability and modernization:**

* The `createResource` function in `resources.test.ts` is now async and waits for the output channel to be ready before returning, improving test reliability. [[1]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afR6-R9) [[2]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afR19-R20)
* All relevant tests in `resources.test.ts` have been converted to async and updated to use the new async `createResource`, ensuring proper sequencing and resource readiness. [[1]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afL25-R31) [[2]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afL36-R44) [[3]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afL52-R64) [[4]](diffhunk://#diff-8dc9585ba92ecee17a410ee33ade2380230adc307391a90f07a97c1fb9baf2afL76-R87)
* The `delay` utility in `watchfilecommand.test.ts` has been simplified for clarity and correctness.
* The test for reusing output channels in `watchfilecommand.test.ts` now explicitly waits for the output window and checks emitter reuse, improving test accuracy.