### PR TITLE
fix: handle file truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [1.0.1](https://github.com/Automattic/vscode-logwatcher/releases/tag/v1.0.0)
+## [1.0.1](https://github.com/Automattic/vscode-logwatcher/releases/tag/v1.0.1)
 
 * Properly handle file truncation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/Automattic/vscode-logwatcher/releases/tag/v1.0.0)
+
+* Properly handle file truncation
+
 ## [1.0.0](https://github.com/Automattic/vscode-logwatcher/releases/tag/v1.0.0)
 
 * First official release
@@ -17,4 +21,4 @@
 
 ## [0.0.1](https://github.com/Automattic/vscode-logwatcher/releases/tag/v0.0.1)
 
-- Initial release.
+* Initial release.

--- a/src/test/suite/watchfilecommand.test.ts
+++ b/src/test/suite/watchfilecommand.test.ts
@@ -1,7 +1,7 @@
 import { deepEqual, equal, match, notEqual } from 'node:assert/strict';
 import { EventEmitter, once } from 'node:events';
 import { WriteStream, createWriteStream } from 'node:fs';
-import { mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, unlink, writeFile, truncate } from 'node:fs/promises';
 import { EOL, platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
@@ -176,5 +176,42 @@ suite('WatchFileCommand', function () {
         const expected = [filename];
         const actual = getFilenames();
         deepEqual(actual, expected);
+    });
+
+
+    test('file truncation', async function () {
+        const fname = join(tmpDir, '0006.txt');
+
+        const expectedContent = '0123456789';
+        await writeFile(fname, expectedContent);
+
+        const [editor, emitter] = await Promise.all([
+            waitForOutputWindow(`extension-output-`),
+            commands.executeCommand<EventEmitter>('logwatcher.watchFile', fname),
+        ]);
+
+        notEqual(editor, undefined);
+        notEqual(emitter, undefined);
+
+        if (!editor.document.getText()) {
+            await waitForVisibleRangesChange(editor);
+        }
+
+        let actual = editor.document.getText();
+        equal(actual, expectedContent);
+
+        const waitForVisibleRangesChangePromise = waitForVisibleRangesChange(editor);
+        const onceFileChangedPromise = once(emitter, 'fileChanged');
+
+        const expectedSize = 5;
+        await truncate(fname, expectedSize);
+
+        await Promise.all([
+            waitForVisibleRangesChangePromise,
+            onceFileChangedPromise,
+        ]);
+
+        actual = editor.document.getText();
+        equal(actual, expectedContent + expectedContent.slice(0, expectedSize));
     });
 });

--- a/src/watchfilecommand.ts
+++ b/src/watchfilecommand.ts
@@ -111,7 +111,7 @@ async function setUpWatcher(filename: string): Promise<Resource | null> {
         try {
             stats = await statFile(filename);
             if (stats) {
-                if (stats.size - offset > 0) {
+                if (stats.size > offset) {
                     fd = await open(filename, 'r');
                     const buffer = Buffer.alloc(stats.size - offset);
                     await fd.read(buffer, 0, buffer.length, offset);

--- a/src/watchfilecommand.ts
+++ b/src/watchfilecommand.ts
@@ -109,13 +109,23 @@ async function setUpWatcher(filename: string): Promise<Resource | null> {
         let fd: FileHandle | undefined;
         let stats: FileStat | null;
         try {
-            [fd, stats] = await Promise.all([open(filename, 'r'), statFile(filename)]);
-
+            stats = await statFile(filename);
             if (stats) {
-                const buffer = Buffer.alloc(stats.size - offset);
-                await fd.read(buffer, 0, buffer.length, offset);
-                offset += buffer.length;
-                outputChannel.append(buffer.toString('ascii'));
+                if (stats.size - offset > 0) {
+                    fd = await open(filename, 'r');
+                    const buffer = Buffer.alloc(stats.size - offset);
+                    await fd.read(buffer, 0, buffer.length, offset);
+                    offset += buffer.length;
+                    outputChannel.append(buffer.toString('ascii'));
+                } else {
+                    offset = stats.size;
+                    const data = await readInitialData(filename, offset);
+                    if (typeof data === 'string') {
+                        outputChannel.append(data);
+                    } else {
+                        throw data;
+                    }
+                }
             }
         } catch (err) {
             outputChannel.appendLine(`*** Failed to read file ${filename}: ${(err as Error).message}`);


### PR DESCRIPTION
This pull request adds proper handling for file truncation in the log watcher and introduces a corresponding test to ensure this functionality works as expected. Additionally, it updates the changelog to reflect the new changes and makes a minor formatting fix.

**File truncation handling:**

* Added logic in `src/watchfilecommand.ts` to detect when a watched file is truncated and handle reading from the new file size correctly.
* Added a new test case in `src/test/suite/watchfilecommand.test.ts` to verify that file truncation is handled properly.
* Imported the `truncate` method from `node:fs/promises` in the test suite to support the new test.

**Documentation:**

* Updated `CHANGELOG.md` to add an entry for version 1.0.1 describing the new file truncation handling, and fixed a minor formatting issue in the initial release entry. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R8) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL20-R24)

Fixes: #73 
